### PR TITLE
Change GitHub URL hackclub/game-lab -> hackclub/gamelab

### DIFF
--- a/components/githubLink.js
+++ b/components/githubLink.js
@@ -29,7 +29,7 @@ export default (state) => (
       @mouseenter=${mouseEnter}
       @click=${click}
       target="_blank"
-      href="https://github.com/hackclub/game-lab"
+      href="https://github.com/hackclub/gamelab"
       >
       <button class="github-button">
         <span class="github-tooltip">GitHub</span>

--- a/components/nameBar.js
+++ b/components/nameBar.js
@@ -56,12 +56,12 @@ export default (state) => (
         </input>
         <div class="powered-by">
           <div>powered by&nbsp;</div>
-          <a href="https://github.com/hackclub/game-lab"
+          <a href="https://github.com/hackclub/gamelab"
              target="_blank">
             <strong>gamelab</strong>
           </a>
           &nbsp;
-          <a href="https://github.com/hackclub/game-lab"
+          <a href="https://github.com/hackclub/gamelab"
              target="_blank">
             <img style="transform: translate(-9px, 3px)" src="./assets/github.png" width="32px" />
           </a>

--- a/getPresignedURL.js
+++ b/getPresignedURL.js
@@ -1,6 +1,6 @@
 // This code doesn't run in the codebase, it's a backup of the code running in AWS Lambda
 
-// Are you editing this on AWS? Please make sure to update github.com/hackclub/game-lab once you deploy.
+// Are you editing this on AWS? Please make sure to update github.com/hackclub/gamelab once you deploy.
 
 // Are you on github? You can find this on https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/getPresignedURL?tab=code
 // Under the logins@hackclub.com account (details in the team 1password)

--- a/github.js
+++ b/github.js
@@ -10,7 +10,7 @@ async function getFromGH() {
   let sha = null;
   try {
     const commits = await fetch(
-      "https://api.github.com/repos/hackclub/game-lab/commits?branch=main&per_page=1"
+      "https://api.github.com/repos/hackclub/gamelab/commits?branch=main&per_page=1"
     ).then((r) => r.json());
     const [latestCommit] = commits;
     sha = latestCommit.sha;


### PR DESCRIPTION
This PR changes references to hackclub/game-lab to hackclub/gamelab in the repo.

While there are no material changes to the AWS Lambda function, we should still deploy this to make sure the repo version and deployed version stay in sync. When merging, please update the code on Lambda as needed.