### PR TITLE
update .show-options styles

### DIFF
--- a/view.js
+++ b/view.js
@@ -284,6 +284,7 @@ export function view(state) {
       }
 
       .show-options {
+        background-color: rgba(0, 0, 0, 25%);
         color: white;
         font-size: 20px;
         font-family: monospace;
@@ -291,6 +292,7 @@ export function view(state) {
         user-select: none;
         right: 10px;
         bottom: 10px;
+        padding: 0 5px;
         display: flex;
         flex-direction: column;
         align-items: flex-end;


### PR DESCRIPTION
this gives the `show-options` div a semitransparent background color, so the text inside can be seen more easily.\
(also, a bit of padding, to make it look a tiny bit better in the wake of the background color.)