### PR TITLE
Prompt rename on save for projects without names

### DIFF
--- a/dispatch.js
+++ b/dispatch.js
@@ -193,7 +193,7 @@ const ACTIONS = {
     });
     const report = {};
     report["Engine Version"] = state.engineVersion;
-    await dispatch("SAVE", { type: "link", copyUrl: false });
+    await dispatch("SAVE", { type: "link", copyUrl: false, nameWarning: false });
     report["Project Link"] = state.lastSaved.link;
     dispatch("NOTIFICATION", {
       message: "Generating a bug report... (2/3)",
@@ -261,7 +261,24 @@ const ACTIONS = {
       version: state.version,
     });
   },
-  SAVE: async ({ type, copyUrl }, state) => {
+  RENAME_PROMPT(){
+    const name = prompt('Would you like to name your project before saving?')
+    const safeName = dispatch('SET_NAME', {name})
+    if (safeName != "my-project") {
+      confirm(`Renamed to '${safeName}'`)
+    }
+  },
+  SAVE: async ({ type, copyUrl, nameWarning=true }, state) => {
+    const defaultNames = [
+      "project-name",
+      "my-project",
+      "name-here",
+      "project-name-here"
+    ]
+    console.log({nameWarning, name: state.name})
+    if (nameWarning && defaultNames.indexOf(state.name) != -1) {
+      await dispatch('RENAME_PROMPT')
+    }
     await save(type, state, copyUrl);
   },
   CANVAS_MOUSE_MOVE({ content: { mouseX, mouseY } }, state) {


### PR DESCRIPTION
Users are prompted to name their projects before saving if they haven't yet...

https://user-images.githubusercontent.com/5891442/159982874-708b8da0-c4e9-4702-a33e-8d554a93bbaa.mov

Only triggers if a name hasn't been set & doesn't trigger on automatic saves (ie. bug report generation)

