### PR TITLE
Implement anykey pressed or held

### DIFF
--- a/Engine.js
+++ b/Engine.js
@@ -681,12 +681,18 @@ class Engine {
     return new Text(str, x, y, ops, this.textContainer);
   }
 
-  heldKey(key) {
-    return this._heldKeys.has(key);
+  ANY_KEY = "AnyKey";
+
+  heldKey(key=this.ANY_KEY) {
+    return key === this.ANY_KEY ?
+      this._heldKeys.size > 0 :
+      this._heldKeys.has(key);
   }
 
-  pressedKey(key) {
-    return this._pressedKeys.has(key);
+  pressedKey(key=this.ANY_KEY) {
+    return key === this.ANY_KEY ?
+      this._pressedKeys.length > 0 :
+      this._pressedKeys.has(key);
   }
 }
 


### PR DESCRIPTION
This is a draft while figuring out the right way to implement this...

_Press [any] key to continue_

<img width="451" alt="Screen Shot 2022-03-31 at 10 58 08" src="https://user-images.githubusercontent.com/5891442/161086258-d5e10eaf-8472-40f3-9847-242c0bff4896.png">

This PR implements checking for any keys being pressed or held. It uses the existing `heldKey()` and `pressedKey()` methods, but now giving them no argument checks for any key. You can also pass in "AnyKey" as the argument for the same effect.

```js
if (e.heldKey()) {
  console.log('A KEY IS PRESSED!!!')
}
if (e.heldKey("AnyKey") {
	console.log("Also means a key is pressed"
}
```

Before merge:
- [ ] Update docs
- [ ] Update examples(?)